### PR TITLE
export LIBGL_ALWAYS_INDIRECT=0 wont work use unset export LIBGL_ALWAY…

### DIFF
--- a/dist/etc/profile.d/kWSL.sh
+++ b/dist/etc/profile.d/kWSL.sh
@@ -32,4 +32,4 @@ export XDG_CONFIG_HOME=$HOME/.config
 export XDG_RUNTIME_DIR=$HOME/.local
 export XDG_CACHE_HOME=$HOME/.cache
 export XDG_DATA_HOME=$HOME/.local/share
-export LIBGL_ALWAYS_INDIRECT=0
+unset LIBGL_ALWAYS_INDIRECT


### PR DESCRIPTION
…S_INDIRECT

Even if LIBGL_ALWAYS_INDIRECT=0 it will be used as enabled. If you really want to deactivate it use unset. Now doblecheck because maybe it is working with this error and my PR will mess the things up. When I install mesa-utils I unset this variable.